### PR TITLE
Linux S3 sleep support and two more useful additions

### DIFF
--- a/Common/DtaDev.cpp
+++ b/Common/DtaDev.cpp
@@ -506,3 +506,9 @@ void DtaDev::puke()
 	if (disk_info.Unknown)
 		cout << "**** " << (uint16_t)disk_info.Unknown << " **** Unknown function codes IGNORED " << std::endl;
 }
+
+uint8_t DtaDev::prepareForS3Sleep(uint8_t lockingrange, char* password)
+{
+    LOG(E) << "S3 sleep not supported on this platform";
+    return 1;
+}

--- a/Common/DtaDev.cpp
+++ b/Common/DtaDev.cpp
@@ -32,6 +32,7 @@ along with sedutil.  If not, see <http://www.gnu.org/licenses/>.
 #include "DtaConstants.h"
 #include "DtaEndianFixup.h"
 #include "DtaHexDump.h"
+#include "DtaHashPwd.h"
 
 using namespace std;
 
@@ -313,6 +314,24 @@ void DtaDev::discovery0()
     while (cpos < epos);
 
 }
+
+uint8_t DtaDev::printPasswordHash(char * password)
+{
+    LOG(D1) << "Entering DtaDev::printPasswordHash()";
+    vector<uint8_t> hash;
+    DtaHashPwd(hash, password, this);
+
+    /* std::hex overwrites flags; save them, so we do not alter other output later */
+    ios_base::fmtflags saved_flags = cout.flags();
+
+    /* First two bytes are actually the opal header */
+    for (size_t i = 2; i < hash.size(); ++i)
+        cout << hex << setfill('0') << setw(2) << (int)hash[i];
+    cout << endl;
+    cout.flags(saved_flags);
+    return 0;
+}
+
 void DtaDev::puke()
 {
 	LOG(D1) << "Entering DtaDev::puke()";

--- a/Common/DtaDev.h
+++ b/Common/DtaDev.h
@@ -262,6 +262,11 @@ public:
 	 * @param password Password of administrative authority for locking range
 	 */
 	virtual uint8_t eraseLockingRange(uint8_t lockingrange, char * password) = 0;
+    /** Optionally implemented s3 sleep support.
+     * On Linux, it saves the password to the kernel to use on resume.
+     * @param password the password to save to the kernel
+     */
+    virtual uint8_t prepareForS3Sleep(uint8_t lockingrange, char* password);
 	/** Dumps an object for diagnostic purposes
 	 * @param sp index into the OPALUID table for the SP the object is in
 	 * @param auth the authority to use for the dump

--- a/Common/DtaDev.h
+++ b/Common/DtaDev.h
@@ -84,6 +84,9 @@ public:
 	 */
 	void discovery0();
 
+	/** Print password hash, computed with this device's serial number
+	 */
+	uint8_t printPasswordHash(char * password);
 	/*
 	 * virtual methods required in the OS specific
 	 * device class

--- a/Common/DtaDev.h
+++ b/Common/DtaDev.h
@@ -294,6 +294,7 @@ public:
 	/** return the communications ID to be used for sessions to this device */
 	virtual uint16_t comID() = 0;
 	bool no_hash_passwords; /** disables hashing of passwords */
+	bool hex_passwords; /** converts passwords from hex before using them */
 	sedutiloutput output_format; /** standard, readable, JSON */
 protected:
 	const char * dev;   /**< character string representing the device in the OS lexicon */

--- a/Common/DtaHashPwd.h
+++ b/Common/DtaHashPwd.h
@@ -41,7 +41,7 @@ void DtaHashPwd(vector<uint8_t> &hash, char * password, DtaDev * device);
  * @param iter number of iterations to be preformed 
  * @param hashsize size of hash to be returned
  */
-void DtaHashPassword(vector<uint8_t> &hash, char * password, vector<uint8_t> salt,
-        unsigned int iter = 75000, uint8_t hashsize = 32);
+void DtaHashPassword(vector<uint8_t> &hash, const vector<uint8_t> &password,
+        const vector<uint8_t> &salt, unsigned int iter = 75000, uint8_t hashsize = 32);
 /** Test the hshing function using publicly available test cased and report */
 int TestPBKDF2();

--- a/Common/DtaOptions.cpp
+++ b/Common/DtaOptions.cpp
@@ -27,10 +27,11 @@ void usage()
     printf("a utility to manage self encrypting drives that conform\n");
     printf("to the TCG Enterprise, Opal, Opalite and Pyrite SSC specs\n");
     printf("General Usage:                     (see readme for extended commandset)\n");
-    printf("sedutil-cli <-v> <-n> <action> <options> <device>\n");
+    printf("sedutil-cli <-v> <-n> <-x> <action> <options> <device>\n");
     printf("-v (optional)                       increase verbosity, one to five v's\n");
     printf("-n (optional)                       no password hashing. Passwords will be sent in clear text!\n");
     printf("-l (optional)                       log style output to stderr only\n");
+    printf("-x (optional)                       password inputs are in hex form\n");
     printf("actions \n");
     printf("--scan \n");
     printf("                                Scans the devices on the system \n");
@@ -143,6 +144,10 @@ uint8_t DtaOptions(int argc, char * argv[], DTA_OPTIONS * opts)
 			baseOptions += 1;
 			opts->output_format = sedutilNormal;
 			outputFormat = sedutilNormal;
+		}
+		else if (!strcmp("-x", argv[i])) {
+			baseOptions += 1;
+            opts->hex_passwords = true;
 		}
 		else if (!(('-' == argv[i][0]) && ('-' == argv[i][1])) && 
 			(0 == opts->action))

--- a/Common/DtaOptions.cpp
+++ b/Common/DtaOptions.cpp
@@ -103,6 +103,9 @@ void usage()
     printf("--printPasswordHash <password> <device>\n");
     printf("                                print the hash of the password \n");
     printf("                                as computed by sedutil. Hex-ecoded.\n");
+    printf("--prepareForS3Sleep <0...n> <Admin1password> <device>\n");
+    printf("                                Automatically unlock range after S3 resume\n");
+    printf("                                This command will save the password to kernel memory\n");
     printf("\n");
     printf("Examples \n");
     printf("sedutil-cli --scan \n");
@@ -527,6 +530,27 @@ uint8_t DtaOptions(int argc, char * argv[], DTA_OPTIONS * opts)
             OPTION_IS(password)
             OPTION_IS(device)
         END_OPTION
+		BEGIN_OPTION(prepareForS3Sleep, 3)
+			TESTARG(0, lockingrange, 0)
+			TESTARG(1, lockingrange, 1)
+			TESTARG(2, lockingrange, 2)
+			TESTARG(3, lockingrange, 3)
+			TESTARG(4, lockingrange, 4)
+			TESTARG(5, lockingrange, 5)
+			TESTARG(6, lockingrange, 6)
+			TESTARG(7, lockingrange, 7)
+			TESTARG(8, lockingrange, 8)
+			TESTARG(9, lockingrange, 9)
+			TESTARG(10, lockingrange, 10)
+			TESTARG(11, lockingrange, 11)
+			TESTARG(12, lockingrange, 12)
+			TESTARG(13, lockingrange, 13)
+			TESTARG(14, lockingrange, 14)
+			TESTARG(15, lockingrange, 15)
+			TESTFAIL("Invalid Locking Range (0-15)")
+			OPTION_IS(password)
+			OPTION_IS(device)
+		END_OPTION
 		BEGIN_OPTION(rawCmd, 7) i += 6; OPTION_IS(device) END_OPTION
 		else {
             LOG(E) << "Invalid command line argument " << argv[i];

--- a/Common/DtaOptions.cpp
+++ b/Common/DtaOptions.cpp
@@ -100,6 +100,9 @@ void usage()
 	printf("                                AdminSP->Revert instead of ThisSP->RevertSP\n");
     printf("--printDefaultPassword <device>\n");
     printf("                                print MSID \n");
+    printf("--printPasswordHash <password> <device>\n");
+    printf("                                print the hash of the password \n");
+    printf("                                as computed by sedutil. Hex-ecoded.\n");
     printf("\n");
     printf("Examples \n");
     printf("sedutil-cli --scan \n");
@@ -520,6 +523,10 @@ uint8_t DtaOptions(int argc, char * argv[], DTA_OPTIONS * opts)
 			END_OPTION
 		BEGIN_OPTION(objDump, 5) i += 4; OPTION_IS(device) END_OPTION
         BEGIN_OPTION(printDefaultPassword, 1) OPTION_IS(device) END_OPTION
+        BEGIN_OPTION(printPasswordHash, 2)
+            OPTION_IS(password)
+            OPTION_IS(device)
+        END_OPTION
 		BEGIN_OPTION(rawCmd, 7) i += 6; OPTION_IS(device) END_OPTION
 		else {
             LOG(E) << "Invalid command line argument " << argv[i];

--- a/Common/DtaOptions.h
+++ b/Common/DtaOptions.h
@@ -97,6 +97,7 @@ typedef enum _sedutiloption {
 	objDump,
     printDefaultPassword,
     printPasswordHash,
+    prepareForS3Sleep,
 	rawCmd,
 
 } sedutiloption;

--- a/Common/DtaOptions.h
+++ b/Common/DtaOptions.h
@@ -43,6 +43,7 @@ typedef struct _DTA_OPTIONS {
 	uint8_t lrlength;		/** the length in blocks of a lockingrange */
 
 	bool no_hash_passwords; /** global parameter, disables hashing of passwords */
+    bool hex_passwords; /** global parameter, all incoming passwords are treated as hex-encoded */
 	sedutiloutput output_format;
 } DTA_OPTIONS;
 /** Print a usage message */

--- a/Common/DtaOptions.h
+++ b/Common/DtaOptions.h
@@ -96,6 +96,7 @@ typedef enum _sedutiloption {
 	validatePBKDF2,
 	objDump,
     printDefaultPassword,
+    printPasswordHash,
 	rawCmd,
 
 } sedutiloption;

--- a/Common/sedutil.cpp
+++ b/Common/sedutil.cpp
@@ -279,6 +279,10 @@ int main(int argc, char * argv[])
 		LOG(D) << "print password hash";
         return d->printPasswordHash(argv[opts.password]);
         break;
+	case sedutiloption::prepareForS3Sleep:
+        LOG(D) << "Preparing for S3 sleep " << (uint16_t) opts.lockingrange;
+        return d->prepareForS3Sleep(opts.lockingrange, argv[opts.password]);
+		break;
 	case sedutiloption::rawCmd:
 		LOG(D) << "Performing cmdDump ";
 		return d->rawCmd(argv[argc - 7], argv[argc - 6], argv[argc - 5], argv[argc - 4], argv[argc - 3], argv[argc - 2]);

--- a/Common/sedutil.cpp
+++ b/Common/sedutil.cpp
@@ -107,6 +107,8 @@ int main(int argc, char * argv[])
 		// make sure DtaDev::no_hash_passwords is initialized
 		d->no_hash_passwords = opts.no_hash_passwords;
 
+		d->hex_passwords = opts.hex_passwords;
+
 		d->output_format = opts.output_format;
 	}
 

--- a/Common/sedutil.cpp
+++ b/Common/sedutil.cpp
@@ -275,6 +275,10 @@ int main(int argc, char * argv[])
 		LOG(D) << "print default password";
         return d->printDefaultPassword();
         break;
+    case sedutiloption::printPasswordHash:
+		LOG(D) << "print password hash";
+        return d->printPasswordHash(argv[opts.password]);
+        break;
 	case sedutiloption::rawCmd:
 		LOG(D) << "Performing cmdDump ";
 		return d->rawCmd(argv[argc - 7], argv[argc - 6], argv[argc - 5], argv[argc - 4], argv[argc - 3], argv[argc - 2]);

--- a/LinuxPBA/UnlockSEDs.cpp
+++ b/LinuxPBA/UnlockSEDs.cpp
@@ -88,6 +88,7 @@ uint8_t UnlockSEDs(char * password) {
             d = new DtaDevOpal1(devref);
         delete tempDev;
         d->no_hash_passwords = false;
+        d->hex_passwords = false;
         failed = 0;
         if (d->Locked()) {
             if (d->MBREnabled()) {

--- a/Makefile.am
+++ b/Makefile.am
@@ -29,7 +29,8 @@ sedutil_cli_SOURCES = linux/Version.h Common/sedutil.cpp Common/DtaOptions.cpp C
 	linux/DtaDevLinuxNvme.cpp linux/DtaDevLinuxNvme.h \
 	linux/DtaDevLinuxSata.cpp linux/DtaDevLinuxSata.h \
 	linux/DtaDevOS.cpp linux/DtaDevOS.h \
-	linux/DtaDevLinuxDrive.h linux/os.h \
+	linux/DtaDevLinuxDrive.cpp linux/DtaDevLinuxDrive.h \
+	linux/os.h \
 	$(SEDUTIL_COMMON_CODE)
 CLEANFILES = linux/Version.h
 BUILT_SOURCES = linux/Version.h
@@ -40,7 +41,8 @@ linuxpba_SOURCES = LinuxPBA/LinuxPBA.cpp LinuxPBA/GetPassPhrase.cpp LinuxPBA/Unl
 	linux/DtaDevLinuxNvme.cpp linux/DtaDevLinuxNvme.h \
 	linux/DtaDevLinuxSata.cpp linux/DtaDevLinuxSata.h \
 	linux/DtaDevOS.cpp linux/DtaDevOS.h \
-	linux/DtaDevLinuxDrive.h linux/os.h \
+	linux/DtaDevLinuxDrive.cpp linux/DtaDevLinuxDrive.h \
+	linux/os.h \
 	\
 	$(SEDUTIL_COMMON_CODE)
 EXTRA_DIST = linux/GitVersion.sh linux/PSIDRevert_LINUX.txt linux/TestSuite.sh README.md docs/sedutil-cli.8

--- a/images/buildroot/packages/sedutil/sedutil.mk
+++ b/images/buildroot/packages/sedutil/sedutil.mk
@@ -17,9 +17,11 @@ define SEDUTIL_POST_EXTRACT_ACTIONS
 sed -i '/^CLEANFILES/d' $(BUILD_DIR)/sedutil-$(SEDUTIL_VERSION)/Makefile.am
 sed -i '/^BUILT_SOURCES/d' $(BUILD_DIR)/sedutil-$(SEDUTIL_VERSION)/Makefile.am
 sed -i '/^linux\/Version/,3 d' $(BUILD_DIR)/sedutil-$(SEDUTIL_VERSION)/Makefile.am
+sed -i 's/^AM_CXXFLAGS.*/\0 -DPBA_BUILD/' $(BUILD_DIR)/sedutil-$(SEDUTIL_VERSION)/Makefile.am
 sed -i '/^BUILT_SOURCES/d' $(BUILD_DIR)/sedutil-$(SEDUTIL_VERSION)/Makefile.in
 sed -i '/^CLEANFILES/d' $(BUILD_DIR)/sedutil-$(SEDUTIL_VERSION)/Makefile.in
 sed -i '/^linux\/Version/,3 d' $(BUILD_DIR)/sedutil-$(SEDUTIL_VERSION)/Makefile.in
+sed -i 's/^AM_CXXFLAGS.*/\0 -DPBA_BUILD/' $(BUILD_DIR)/sedutil-$(SEDUTIL_VERSION)/Makefile.in
 endef
 SEDUTIL_POST_EXTRACT_HOOKS += SEDUTIL_POST_EXTRACT_ACTIONS
 $(eval $(autotools-package))

--- a/linux/DtaDevLinuxDrive.cpp
+++ b/linux/DtaDevLinuxDrive.cpp
@@ -1,0 +1,46 @@
+/* C:B**************************************************************************
+Copyright 2017, Alex Badics
+
+This file is part of sedutil.
+
+sedutil is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+sedutil is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with sedutil.  If not, see <http://www.gnu.org/licenses/>.
+
+ * C:E********************************************************************** */
+#include "os.h"
+#include <sys/ioctl.h>
+#include <linux/sed-opal.h>
+#include "DtaDevLinuxDrive.h"
+
+using namespace std;
+
+uint8_t DtaDevLinuxDrive::prepareForS3Sleep(uint8_t lockingrange, const vector<uint8_t> &password_hash)
+{
+    LOG(D1) << "Entering DtaDevLinuxDrive::prepareForS3Sleep";
+
+    opal_lock_unlock opal_ioctl_data={};
+    opal_ioctl_data.l_state = OPAL_RW;
+    opal_ioctl_data.session.who = OPAL_ADMIN1;
+    opal_ioctl_data.session.opal_key.lr = 0;
+
+    size_t hash_len=min(password_hash.size(), sizeof(opal_ioctl_data.session.opal_key.key));
+    LOG(D2) << "Setting a hash of length" << hash_len;
+
+    memcpy(opal_ioctl_data.session.opal_key.key, &password_hash[0], hash_len);
+    opal_ioctl_data.session.opal_key.key_len = hash_len;
+
+    int err = ioctl(fd, IOC_OPAL_SAVE, &opal_ioctl_data);
+    if (err < 0)
+        return errno;
+    return 0;
+}

--- a/linux/DtaDevLinuxDrive.cpp
+++ b/linux/DtaDevLinuxDrive.cpp
@@ -31,7 +31,7 @@ uint8_t DtaDevLinuxDrive::prepareForS3Sleep(uint8_t lockingrange, const vector<u
     opal_lock_unlock opal_ioctl_data={};
     opal_ioctl_data.l_state = OPAL_RW;
     opal_ioctl_data.session.who = OPAL_ADMIN1;
-    opal_ioctl_data.session.opal_key.lr = 0;
+    opal_ioctl_data.session.opal_key.lr = lockingrange;
 
     size_t hash_len=min(password_hash.size(), sizeof(opal_ioctl_data.session.opal_key.key));
     LOG(D2) << "Setting a hash of length" << hash_len;

--- a/linux/DtaDevLinuxDrive.cpp
+++ b/linux/DtaDevLinuxDrive.cpp
@@ -19,8 +19,10 @@ along with sedutil.  If not, see <http://www.gnu.org/licenses/>.
  * C:E********************************************************************** */
 #include "os.h"
 #include <sys/ioctl.h>
-#include <linux/sed-opal.h>
 #include "DtaDevLinuxDrive.h"
+#ifndef PBA_BUILD
+#include <linux/sed-opal.h>
+#endif
 
 using namespace std;
 
@@ -28,6 +30,10 @@ uint8_t DtaDevLinuxDrive::prepareForS3Sleep(uint8_t lockingrange, const vector<u
 {
     LOG(D1) << "Entering DtaDevLinuxDrive::prepareForS3Sleep";
 
+#ifdef PBA_BUILD
+    LOG(E) << "prepareForS3Sleep not supported in PBA build";
+    return -1;
+#else
     opal_lock_unlock opal_ioctl_data={};
     opal_ioctl_data.l_state = OPAL_RW;
     opal_ioctl_data.session.who = OPAL_ADMIN1;
@@ -43,4 +49,5 @@ uint8_t DtaDevLinuxDrive::prepareForS3Sleep(uint8_t lockingrange, const vector<u
     if (err < 0)
         return errno;
     return 0;
+#endif
 }

--- a/linux/DtaDevLinuxDrive.h
+++ b/linux/DtaDevLinuxDrive.h
@@ -18,8 +18,10 @@ along with sedutil.  If not, see <http://www.gnu.org/licenses/>.
 
  * C:E********************************************************************** */
 #pragma once
+#include <vector>
 #include "DtaStructures.h"
 
+using namespace std;
 /** virtual implementation for a disk interface-generic disk drive
  */
 class DtaDevLinuxDrive {
@@ -45,4 +47,7 @@ public:
             void * buffer, uint32_t bufferlen) = 0;
     /** Routine to send an identify to the device */
     virtual void identify(OPAL_DiskInfo& disk_info) = 0;
+    /** Save the password hash to the kernel for S3 sleep wakeup */
+    uint8_t prepareForS3Sleep(uint8_t lockingrange, const vector<uint8_t> &password_hash);
+    int fd; /**< Linux handle for the device  */
 };

--- a/linux/DtaDevLinuxNvme.h
+++ b/linux/DtaDevLinuxNvme.h
@@ -59,5 +59,4 @@ public:
             void * buffer, uint32_t bufferlen);
     /** NVMe specific routine to send an identify to the device */
     void identify(OPAL_DiskInfo& disk_info);
-    int fd; /**< Linux handle for the device  */
 };

--- a/linux/DtaDevLinuxSata.h
+++ b/linux/DtaDevLinuxSata.h
@@ -55,6 +55,5 @@ public:
             void * buffer, uint32_t bufferlen);
     /** Linux specific routine to send an ATA identify to the device */
     void identify_SAS(OPAL_DiskInfo *disk_info);
-    int fd; /**< Linux handle for the device  */
     int isSAS; /* The device is sas */
 };

--- a/linux/DtaDevOS.cpp
+++ b/linux/DtaDevOS.cpp
@@ -191,7 +191,7 @@ uint8_t DtaDevOS::prepareForS3Sleep(uint8_t lockingrange, char* password)
     DtaHashPwd(hash, password, this);
     hash.erase(hash.begin(), hash.begin()+2);
 
-    err = drive->prepareForS3Sleep(0, hash);
+    err = drive->prepareForS3Sleep(lockingrange, hash);
     if (err)
     {
         LOG(E) << "Error saving the password to  the kernel errno = " << errno;

--- a/linux/DtaDevOS.cpp
+++ b/linux/DtaDevOS.cpp
@@ -38,6 +38,9 @@ along with sedutil.  If not, see <http://www.gnu.org/licenses/>.
 #include "DtaDevLinuxSata.h"
 #include "DtaDevLinuxNvme.h"
 #include "DtaDevGeneric.h"
+#include "DtaHashPwd.h"
+#include "DtaSession.h"
+#include "DtaDevOpal.h"
 
 using namespace std;
 
@@ -165,6 +168,36 @@ int  DtaDevOS::diskScan()
 	printf("No more disks present ending scan\n");
         LOG(D1) << "Exiting DtaDevOS::scanDisk ";
 	return 0;
+}
+
+uint8_t DtaDevOS::prepareForS3Sleep(uint8_t lockingrange, char* password)
+{
+    LOG(D1) << "Entering DtaDevOS::prepareForS3Sleep ";
+    LOG(D2) << "Starting testing of password ";
+	session = new DtaSession(this);
+	if (NULL == session) {
+		LOG(E) << "Unable to create session object ";
+		return DTAERROR_OBJECT_CREATE_FAILED;
+	}
+    int err;
+	if ((err = session->start(OPAL_UID::OPAL_LOCKINGSP_UID, password, OPAL_UID::OPAL_ADMIN1_UID)) != 0) {
+		delete session;
+		LOG(E) << "Unable to authenticate with the given password";
+		return err;
+	}
+    delete session;
+    LOG(D2) << "Test successful, saving it to kernel ";
+    vector<uint8_t> hash;
+    DtaHashPwd(hash, password, this);
+    hash.erase(hash.begin(), hash.begin()+2);
+
+    err = drive->prepareForS3Sleep(0, hash);
+    if (err)
+    {
+        LOG(E) << "Error saving the password to  the kernel errno = " << errno;
+        return errno;
+    }
+    return 0;
 }
 
 /** Close the device reference so this object can be delete. */

--- a/linux/DtaDevOS.h
+++ b/linux/DtaDevOS.h
@@ -49,6 +49,8 @@ public:
             void * buffer, uint32_t bufferlen);
     /** A static class to scan for supported drives */
     static int diskScan();
+    /** Save device key to kernel for S3 sleep resume */
+    uint8_t prepareForS3Sleep(uint8_t lockingrange, char* password);
 protected:
     /** OS specific command to Wait for specified number of milliseconds 
      * @param ms  number of milliseconds to wait


### PR DESCRIPTION
This adds the three commits from https://github.com/fabiogermann/sedutil:
- Add option to use non-ascii passwords
- Option to print the password hash
- S3 sleep support for Linux

See comments in the commit messages.

Would it be difficult to develop inserting the hash when waking up on FreeBSD or do we have another mechanism for this?